### PR TITLE
Disable Expect Header prior to POST

### DIFF
--- a/opsviewctl_downtime.ps1
+++ b/opsviewctl_downtime.ps1
@@ -46,6 +46,7 @@ $bytes = [System.Text.Encoding]::ASCII.GetBytes($credentials)
 $request = [System.Net.WebRequest]::Create("http://" + $server + $urlauthenticate)
 $request.Method = "POST"
 $request.ContentLength = $bytes.Length
+$request.ServicePoint.Expect100Continue = $false
 $request.ContentType = "application/json"
 $stream = $request.GetRequestStream()
 $stream.Write($bytes,0,$bytes.Length)


### PR DESCRIPTION
The issue is that the .NET client set the expect header and only send the request headers before a POST of data. This allows the server to respond with errors/redirects/security violations prior to the client sending the request body. The client does not wait until it gets a response and just pushes out the body of the request, which results in a 417 expectation error on my apache 2.2 and requesting auth token failed.